### PR TITLE
fix: dependency source map support not found issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "joi": "17.6.0",
     "reflect-metadata": "0.1.13",
     "rimraf": "3.0.2",
-    "rxjs": "7.5.5"
+    "rxjs": "7.5.5",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@nestjs/cli": "8.2.5",
@@ -50,7 +51,6 @@
     "jest": "28.0.3",
     "prettier": "^2.8.7",
     "prisma": "3.13.0",
-    "source-map-support": "^0.5.21",
     "supertest": "6.2.3",
     "ts-jest": "27.1.4",
     "ts-loader": "9.3.0",


### PR DESCRIPTION
According to [the refered issue](https://github.com/Polymer/tools/issues/816), `source-map-support` not in `dependencies` but `devDependencies` in `package.json` causes `Error: Cannot find module 'source-map-support/register`.

Fixed it by moving the dependency from `devDependencies` to `dependencies`.