### PR TITLE
refactor: import SettingConfigModule from UserModule to maintain the pattern

### DIFF
--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -2,12 +2,11 @@ import { Module } from '@nestjs/common';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { BotModule } from '@/bot/bot.module';
-import { SettingsConfigService } from '@/constants/settings.service';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { SettingsConfigModule } from '@/constants/settings.module';
 
 @Module({
-  imports: [BotModule, ConfigModule],
-  providers: [UserService, SettingsConfigService, ConfigService],
+  imports: [BotModule, SettingsConfigModule],
+  providers: [UserService],
   controllers: [UserController],
 })
 export class UserModule {}


### PR DESCRIPTION
No need to import all the Services related to the `SettingsConfigModule` to get the guild ID.
Just needed importing only the `SettingsConfigModule`.